### PR TITLE
Adding dockerfie, helm-chart and argocd app

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ docker compose logs -f
 - **TARGET_EMAIL_ADDRESS**: The email address to monitor e.g. *info@netflix.com*
 - **TARGET_EMAIL_SUBJECT**: The email subject to monitor e.g. *"How to update your Netflix household"*
 
+## Docker image build
+`docker buildx build     --builder armbuilder     --platform linux/arm64,linux/amd64 --push     --no-cache     -f imap-netflix-household-automation.dockerfile     -t dawidch/imap-netflix-household-automation:1.0.0     --progress=plain  --network host   .`
+
+## ArgoCD
+Application custom resource to use with argocd deployment.
+
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/) © [Duc Phung](https://github.com/ducphu0ng)

--- a/argocd/imap-netflix-household-automation.yaml
+++ b/argocd/imap-netflix-household-automation.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: netflix-household-automation
+  namespace: argocd
+
+spec:
+  project: default
+
+  source:
+    repoURL: git@github.com:ducphu0ng/imap-netflix-household-automation
+    targetRevision: main
+    path: helm-chart
+
+    helm:
+      valueFiles:
+        - ../helm-values/values.yaml
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: netflix-household-automation
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+      - CreateNamespace=true

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: imap-netflix-household-automation
+description: Netflix household IMAP automation
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "netflix.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}                

--- a/helm-chart/templates/config-map.yaml
+++ b/helm-chart/templates/config-map.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "netflix.fullname" . }}-config
+data:
+  IMAP_HOST: {{ .Values.config.imapHost | quote }}
+  IMAP_PORT: {{ .Values.config.imapPort | quote }}
+  TARGET_EMAIL_ADDRESS: {{ .Values.config.targetEmailAddress | quote }}
+  TARGET_EMAIL_SUBJECT: {{ .Values.config.targetEmailSubject | quote }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netflix.fullname" . }}
+spec:
+  replicas: 1
+
+  selector:
+    matchLabels:
+      app: {{ include "netflix.fullname" . }}
+
+  template:
+    metadata:
+      labels:
+        app: {{ include "netflix.fullname" . }}
+
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecretName }}
+      containers:
+        - name: netflix
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          envFrom:
+            - secretRef:
+                name: {{ include "netflix.fullname" . }}-secret
+            - configMapRef:
+                name: {{ include "netflix.fullname" . }}-config
+
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK

--- a/helm-chart/templates/secret.yaml
+++ b/helm-chart/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netflix.fullname" . }}-secret
+type: Opaque
+stringData:
+  IMAP_USER: {{ .Values.secret.imapUser | quote }}
+  IMAP_PASSWORD: {{ .Values.secret.imapPassword | quote }}

--- a/helm-values/values.yaml
+++ b/helm-values/values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: docker.io/dawidch/imap-netflix-household-automation
+  tag: 1.0.0
+  pullPolicy: IfNotPresent
+  pullSecretName: <pull-secret-to-image-registry>
+
+containerName: netflix-household-automation
+namespace: automation
+
+secret:
+  imapUser: <user>@gmail.com
+  imapPassword: <password-or-app-password>
+
+config:
+  imapHost: imap.gmail.com
+  imapPort: "993"
+  targetEmailAddress: info@account.netflix.com
+  targetEmailSubject: <full-email-subject-to-monitor>

--- a/netflix-household-automation.dockerfile
+++ b/netflix-household-automation.dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/playwright:v1.51.1-jammy
+
+WORKDIR /app
+
+COPY package.json yarn.lock tsconfig.json ./
+COPY src/ /app/src
+RUN yarn install --frozen-lockfile --network-timeout 600000
+
+CMD ["yarn", "start"]


### PR DESCRIPTION
Hey.
My contribution to your great work. I've built and pushed Docker images for both `arm64` (for OCI Ampere) and `amd64` platforms to `https://hub.docker.com/repository/docker/dawidch/imap-netflix-household-automation/tags`. I've also added a Helm chart and an ArgoCD Application CR. This setup makes it easy to deploy your application to Kubernetes, which was the only thing missing from your repository. Now you have it all :)

<img width="220" height="220" alt="image" src="https://github.com/user-attachments/assets/b35598a1-4e43-4edc-ac09-1a2212d73c3f" />
